### PR TITLE
cargo outdated only check root deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,4 +81,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/install@cargo-outdated
-      - run: cargo outdated --exit-code 1
+      - run: cargo outdated -R --exit-code 1


### PR DESCRIPTION
`cargo outdated` should only check root deps.
We can only upgrade root deps.