### PR TITLE
Add format date writer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+dhat-heap.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added `timestamp` arg for format fns
+  The `Timestamp` type accepts preformatted timestamps in 
+  `&str`, `String` and `&[u8]` forms
+- Changed the timestamp formatting to use a custom
+  formatter that doesn't allocate on the heap.
+- Changed formatting a messsage without structured data does not use any
+  heap allocations. See the test folder for verifications of this.
 - Removed unused Error type.
 
 ## [0.2.0] - 2023-04-20

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,16 @@ chrono = { version = "0.4.24", optional = true, default-features = false, featur
 [dev-dependencies]
 arrayvec = "0.7.2"
 assert_matches = "1.5.0"
+dhat = "0.3.2"
 env_logger = "0.10.0"
 is-terminal = "0.4.7"
 log = "0.4.17"
 parking_lot = "0.12.1"
+
+[[test]]
+name = "assert_no_heap_allocations"
+harness = false
+
+[[test]]
+name = "assert_heap_allocations_with_structured_data"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,12 @@ repository = "https://github.com/tandemdrive/syslog-fmt"
 rust-version = "1.60"
 version = "0.2.0"
 
+[features]
+default = ["chrono"]
+chrono = ["dep:chrono"]
+
 [dependencies]
-chrono = { version = "0.4.24", default-features = false, features = ["clock"]}
+chrono = { version = "0.4.24", optional = true, default-features = false, features = ["clock"]}
 
 [dev-dependencies]
 arrayvec = "0.7.2"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Read through the [examples](examples) to see basic usages of the formatter with 
 ## Why this crate?
 
 - Minimal [dependencies](Cargo.toml)
+- No [heap](tests/assert_no_heap_allocations.rs) allocations are performed when logging without structured data.
 - 100% safe Rust 🦀code upheld by [clippy](.cargo/config.toml) [workflow](.github/workflows/ci.yml)
 
 

--- a/examples/default_config.rs
+++ b/examples/default_config.rs
@@ -1,6 +1,9 @@
 use std::io;
 
-use syslog_fmt::{v5424, Severity};
+use syslog_fmt::{
+    v5424::{self, Timestamp},
+    Severity,
+};
 
 fn main() -> io::Result<()> {
     let formatter = v5424::Config {
@@ -13,6 +16,7 @@ fn main() -> io::Result<()> {
     formatter.format(
         &mut buf,
         Severity::Info,
+        Timestamp::UseChrono,
         "'su root' failed for lonvick on /dev/pts/8",
         None,
     )?;

--- a/examples/default_config.rs
+++ b/examples/default_config.rs
@@ -16,7 +16,7 @@ fn main() -> io::Result<()> {
     formatter.format(
         &mut buf,
         Severity::Info,
-        Timestamp::UseChrono,
+        Timestamp::CreateChronoLocal,
         "'su root' failed for lonvick on /dev/pts/8",
         None,
     )?;

--- a/examples/simple_datagram_based_logger.rs
+++ b/examples/simple_datagram_based_logger.rs
@@ -17,7 +17,10 @@ mod unix {
     use arrayvec::ArrayVec;
     use is_terminal::IsTerminal;
     use parking_lot::Mutex;
-    use syslog_fmt::{v5424, Facility, Severity};
+    use syslog_fmt::{
+        v5424::{self, Timestamp},
+        Facility, Severity,
+    };
 
     const SYSLOG_MSG_BUFFER_LEN: usize = 1024;
 
@@ -37,9 +40,13 @@ mod unix {
             if self.enabled(record.metadata()) {
                 let mut buf = self.buf.lock();
 
-                let res = self
-                    .formatter
-                    .format(&mut *buf, Severity::Info, record.args(), None);
+                let res = self.formatter.format(
+                    &mut *buf,
+                    Severity::Info,
+                    Timestamp::UseChrono,
+                    record.args(),
+                    None,
+                );
 
                 if let Err(e) = res {
                     // ignore when the buffer runs over capcity
@@ -73,9 +80,13 @@ mod unix {
             if self.enabled(record.metadata()) {
                 let mut buf = self.buf.lock();
 
-                let res = self
-                    .formatter
-                    .format(&mut *buf, Severity::Info, record.args(), None);
+                let res = self.formatter.format(
+                    &mut *buf,
+                    Severity::Info,
+                    Timestamp::UseChrono,
+                    record.args(),
+                    None,
+                );
 
                 if let Err(e) = res {
                     // ignore when the buffer runs over capcity

--- a/examples/simple_datagram_based_logger.rs
+++ b/examples/simple_datagram_based_logger.rs
@@ -43,7 +43,7 @@ mod unix {
                 let res = self.formatter.format(
                     &mut *buf,
                     Severity::Info,
-                    Timestamp::UseChrono,
+                    Timestamp::CreateChronoLocal,
                     record.args(),
                     None,
                 );
@@ -83,7 +83,7 @@ mod unix {
                 let res = self.formatter.format(
                     &mut *buf,
                     Severity::Info,
-                    Timestamp::UseChrono,
+                    Timestamp::CreateChronoLocal,
                     record.args(),
                     None,
                 );

--- a/examples/unix_datagram.rs
+++ b/examples/unix_datagram.rs
@@ -11,7 +11,10 @@ fn main() -> io::Result<()> {
 mod unix {
     use std::{io, os::unix::net::UnixDatagram};
 
-    use syslog_fmt::{v5424, Facility, Severity};
+    use syslog_fmt::{
+        v5424::{self, Timestamp},
+        Facility, Severity,
+    };
 
     pub fn run() -> io::Result<()> {
         const UNIX_SOCK_PATHS: [&str; 3] = ["/dev/log", "/var/run/syslog", "/var/run/log"];
@@ -30,6 +33,7 @@ mod unix {
         formatter.format(
             &mut buf,
             Severity::Info,
+            Timestamp::UseChrono,
             "'su root' failed for lonvick on /dev/pts/8",
             None,
         )?;

--- a/examples/unix_datagram.rs
+++ b/examples/unix_datagram.rs
@@ -33,7 +33,7 @@ mod unix {
         formatter.format(
             &mut buf,
             Severity::Info,
-            Timestamp::UseChrono,
+            Timestamp::CreateChronoLocal,
             "'su root' failed for lonvick on /dev/pts/8",
             None,
         )?;

--- a/tests/assert_heap_allocations_with_structured_data.rs
+++ b/tests/assert_heap_allocations_with_structured_data.rs
@@ -1,0 +1,60 @@
+use std::io;
+
+use arrayvec::ArrayVec;
+use syslog_fmt::{
+    v5424::{self, Timestamp},
+    Severity,
+};
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+fn main() -> io::Result<()> {
+    let profiler = dhat::Profiler::builder().testing().build();
+    // the first call to Local::new initializes a thread safe cache within chrono
+    let _datetime = chrono::Local::now();
+    let stats = dhat::HeapStats::get();
+
+    dhat::assert!(
+        5500 <= stats.total_bytes && stats.total_bytes <= 6500,
+        "The chrono cache heap allocation should be in the 6kb range"
+    );
+
+    // only one Profiler can run at a time
+    drop(profiler);
+
+    // the creation of a Formatter allocates on the heaps
+    let formatter = v5424::Config {
+        app_name: Some("default_config_example"),
+        ..Default::default()
+    }
+    .into_formatter();
+
+    let _profiler = dhat::Profiler::builder().testing().build();
+
+    let mut buf = ArrayVec::<u8, 256>::new();
+
+    formatter
+        .format_with_data(
+            &mut buf,
+            Severity::Info,
+            Timestamp::CreateChronoLocal,
+            "'su root' failed for lonvick on /dev/pts/8",
+            None,
+            vec![(
+                "exampleSDID@32473",
+                vec![
+                    ("iut", "3"),
+                    ("eventSource", "Application"),
+                    ("eventID", "1011"),
+                ],
+            )],
+        )
+        .unwrap();
+
+    let stats = dhat::HeapStats::get();
+
+    dhat::assert_eq!(stats.total_bytes, 589);
+
+    Ok(())
+}

--- a/tests/assert_no_heap_allocations.rs
+++ b/tests/assert_no_heap_allocations.rs
@@ -1,0 +1,50 @@
+use std::io;
+
+use arrayvec::ArrayVec;
+use syslog_fmt::{
+    v5424::{self, Timestamp},
+    Severity,
+};
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+fn main() -> io::Result<()> {
+    let profiler = dhat::Profiler::builder().testing().build();
+    // the first call to Local::new initializes a thread safe cache within chrono
+    let _datetime = chrono::Local::now();
+    let stats = dhat::HeapStats::get();
+
+    dhat::assert!(
+        5500 <= stats.total_bytes && stats.total_bytes <= 6500,
+        "The chrono cache heap allocation should be in the 6kb range"
+    );
+
+    // only one Profiler can run at a time
+    drop(profiler);
+
+    // the creation of a Formatter allocates on the heaps
+    let formatter = v5424::Config {
+        app_name: Some("default_config_example"),
+        ..Default::default()
+    }
+    .into_formatter();
+
+    let _profiler = dhat::Profiler::builder().testing().build();
+
+    let mut buf = ArrayVec::<u8, 128>::new();
+
+    formatter.format(
+        &mut buf,
+        Severity::Info,
+        Timestamp::CreateChronoLocal,
+        "'su root' failed for lonvick on /dev/pts/8",
+        None,
+    )?;
+
+    let stats = dhat::HeapStats::get();
+
+    dhat::assert_eq!(stats.total_bytes, 0);
+
+    Ok(())
+}


### PR DESCRIPTION
Added custom formatter for RFC3339 dates as described in the syslog 5424 spec.
The custom formatter improves on the chrono impl by not allocating to the heap.
The chrono formatter is very flexible, but that level of flexibility is unnecessary for
a syslog formatter.

I also added a `timestamp` argument to the format fns so the caller can decide how
to supply a timestamp. Preformatted timestamps are not possible.

Using the `chrono` dependency is now optional and is enabled be default.

I added two heap allocation tests to verify that formatting a syslog message without structured data
does not allocate data on the heap.