### PR TITLE
Split format msg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Renamed `format_*` fns to `write_*` to emphasize that they utilize a Writer.
 - timestamp formatting uses a custom formatter that doesn't allocate on the heap.
-- formatting a messsage with and without structured data does not perform any
+- formatting a message with and without structured data does not perform any
   heap allocations. See the test folder for verifications of this.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,40 +7,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Added `timestamp` arg for format fns
+### Added 
+
+- `timestamp` arg for format fns
   The `Timestamp` type accepts preformatted timestamps in 
   `&str`, `String` and `&[u8]` forms
-- Changed the timestamp formatting to use a custom
-  formatter that doesn't allocate on the heap.
-- Changed formatting a messsage without structured data does not use any
+- Fine grained fns for writing header, structured data and message UTF8 BOM.
+  These can be used to write/format a message piece by piece without heap allocations
+
+### Changed
+
+- Renamed `format_*` fns to `write_*` to emphasize that they utilize a Writer.
+- timestamp formatting uses a custom formatter that doesn't allocate on the heap.
+- formatting a messsage with and without structured data does not perform any
   heap allocations. See the test folder for verifications of this.
-- Removed unused Error type.
+
+### Removed
+
+- Unused Error type.
 
 ## [0.2.0] - 2023-04-20
 
-- Added `From<Config> for Formatter` and `impl Default` for `Config` and `Formatter`.
-- Removed `fn exe_name_from_env`.
+### Added 
+
+- `From<Config> for Formatter` and `impl Default` for `Config` and `Formatter`.
+
+### Removed 
+
+- `fn exe_name_from_env`.
   This can easily be provided by the user.
-- Removed `Cargo.lock` as this is a library.
+- `Cargo.lock` as this is a library.
 
 ## [0.1.2] - 2023-04-19
 
-- Add `simple_datagram_based_logger` example
-- Add CONTRIBUTING.md
-- Change rustdoc 
-  - rephrase comments that quote the spec
-  - include link to spec sections in comments
-- Change README
-  - Add project goal
+### Added
+
+- `simple_datagram_based_logger` example
+- CONTRIBUTING.md
+
+### Changed
+
+- Rephrased rustdoc comments that quote the spec and include link to spec sections in comments
+- Improve docs
+  - Add project goal to README
   - include link to examples
   - include Contributing section
   - include License section
 
 ## [0.1.1] - 2023-04-17
 
+### Changed
+
 - Moved repo from `bheylin` account to `tandemdrive` org.
 - Updated Cargo.toml to Tandemdrive details.
 
 ## [0.1.0] - 2023-04-17
 
-- Added formatter for 5424 syslog spec.
+### Added
+
+- formatter for 5424 syslog spec.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,9 @@ log = "0.4.17"
 parking_lot = "0.12.1"
 
 [[test]]
-name = "assert_no_heap_allocations"
+name = "assert_no_heap_allocations_without_structured_data"
 harness = false
 
 [[test]]
-name = "assert_heap_allocations_with_structured_data"
+name = "assert_no_heap_allocations_with_structured_data"
 harness = false

--- a/examples/default_config.rs
+++ b/examples/default_config.rs
@@ -13,7 +13,7 @@ fn main() -> io::Result<()> {
     .into_formatter();
 
     let mut buf = Vec::<u8>::new();
-    formatter.format(
+    formatter.write_without_data(
         &mut buf,
         Severity::Info,
         Timestamp::CreateChronoLocal,

--- a/examples/simple_datagram_based_logger.rs
+++ b/examples/simple_datagram_based_logger.rs
@@ -40,7 +40,7 @@ mod unix {
             if self.enabled(record.metadata()) {
                 let mut buf = self.buf.lock();
 
-                let res = self.formatter.format(
+                let res = self.formatter.write_without_data(
                     &mut *buf,
                     Severity::Info,
                     Timestamp::CreateChronoLocal,
@@ -80,7 +80,7 @@ mod unix {
             if self.enabled(record.metadata()) {
                 let mut buf = self.buf.lock();
 
-                let res = self.formatter.format(
+                let res = self.formatter.write_without_data(
                     &mut *buf,
                     Severity::Info,
                     Timestamp::CreateChronoLocal,

--- a/examples/unix_datagram.rs
+++ b/examples/unix_datagram.rs
@@ -30,7 +30,7 @@ mod unix {
         .into_formatter();
 
         let mut buf = Vec::<u8>::new();
-        formatter.format(
+        formatter.write_without_data(
             &mut buf,
             Severity::Info,
             Timestamp::CreateChronoLocal,

--- a/src/v5424.rs
+++ b/src/v5424.rs
@@ -224,7 +224,7 @@ impl Formatter {
 ///
 /// An SD-ELEMENT consists of a name and parameter name-value pairs. The
 /// name is referred to as SD-ID. The name-value pairs are referred to
-/// as [SdParam].
+/// as SD-PARAM.
 ///
 /// [spec](https://datatracker.ietf.org/doc/html/rfc5424#section-6.3.1)
 pub fn write_data<'a, W, I, P>(w: &mut W, data: I) -> io::Result<()>
@@ -386,7 +386,7 @@ pub enum Timestamp<'a> {
     /// A custom formatter is used that does not perform any heap allcations
     #[cfg(feature = "chrono")]
     Chrono(&'a ChronoLocalTime),
-    /// The formatter will create a new chrono::DateTime<Local>
+    /// The formatter will create a new `chrono::DateTime<Local>`
     /// A custom formatter is used that does not perform any heap allcations
     #[cfg(feature = "chrono")]
     CreateChronoLocal,
@@ -571,7 +571,7 @@ impl<'a> From<&'a fmt::Arguments<'a>> for Msg<'a> {
 }
 
 /// [SdId]s are case-sensitive and uniquely identify the type and purpose
-/// of the [SdElement]. The same [SdId] MUST NOT exist more than once in a
+/// of the SD-ELEMENT. The same [SdId] MUST NOT exist more than once in a
 /// message.
 ///
 /// There are two formats for [SdId] names:

--- a/tests/assert_no_heap_allocations_with_structured_data.rs
+++ b/tests/assert_no_heap_allocations_with_structured_data.rs
@@ -25,15 +25,15 @@ fn main() -> io::Result<()> {
     let mut buf = ArrayVec::<u8, 256>::new();
 
     formatter
-        .format_with_data(
+        .write_with_data(
             &mut buf,
             Severity::Info,
             Timestamp::CreateChronoLocal,
             "'su root' failed for lonvick on /dev/pts/8",
             None,
-            vec![(
+            [(
                 "exampleSDID@32473",
-                vec![
+                [
                     ("iut", "3"),
                     ("eventSource", "Application"),
                     ("eventID", "1011"),
@@ -44,7 +44,7 @@ fn main() -> io::Result<()> {
 
     let stats = dhat::HeapStats::get();
 
-    dhat::assert_eq!(stats.total_bytes, 589);
+    dhat::assert_eq!(stats.total_bytes, 0);
 
     Ok(())
 }

--- a/tests/assert_no_heap_allocations_without_structured_data.rs
+++ b/tests/assert_no_heap_allocations_without_structured_data.rs
@@ -24,7 +24,7 @@ fn main() -> io::Result<()> {
 
     let mut buf = ArrayVec::<u8, 128>::new();
 
-    formatter.format(
+    formatter.write_without_data(
         &mut buf,
         Severity::Info,
         Timestamp::CreateChronoLocal,


### PR DESCRIPTION
- Added fine grained fns for writing header, structured data and message UTF8 BOM.
  These can be used to write/format a message piece by piece without heap allocations
- Renamed `format_*` fns to `write_*` to emphasize that they utilize a Writer.
- formatting a message with and without structured data does not perform any
  heap allocations. See the test folder for verifications of this.
